### PR TITLE
Fixed error shown when importing icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "storybook": "^7.0.0-beta.8",
         "svelte": "^3.55.1",
         "svelte-check": "^2.9.2",
-        "svelte-icons-pack": "^2.0.0",
+        "svelte-icons-pack": "^2.1.0",
         "svelte-preprocess": "^5.0.0",
         "tailwindcss": "^3.2.4",
         "tslib": "^2.4.1",
@@ -13302,9 +13302,9 @@
       }
     },
     "node_modules/svelte-icons-pack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-icons-pack/-/svelte-icons-pack-2.0.0.tgz",
-      "integrity": "sha512-B0EjVQrdURQCY/n//vBmJA/cbrT6ngv6Ja4FXVXUlZjcSKhoXpIgmcQQ0lPH5PpCcJNKbDQYyxPnUW1KTrkWJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-icons-pack/-/svelte-icons-pack-2.1.0.tgz",
+      "integrity": "sha512-6Il0vWi/6MW3wXSorZhCqhkJGH4Pcg1WTcdlfFMPXfJqafZVQgmKdhVFS1c2hXGvs4byttpLC9XmI3okV1uMWA==",
       "dev": true
     },
     "node_modules/svelte-preprocess": {
@@ -24340,9 +24340,9 @@
       "requires": {}
     },
     "svelte-icons-pack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-icons-pack/-/svelte-icons-pack-2.0.0.tgz",
-      "integrity": "sha512-B0EjVQrdURQCY/n//vBmJA/cbrT6ngv6Ja4FXVXUlZjcSKhoXpIgmcQQ0lPH5PpCcJNKbDQYyxPnUW1KTrkWJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-icons-pack/-/svelte-icons-pack-2.1.0.tgz",
+      "integrity": "sha512-6Il0vWi/6MW3wXSorZhCqhkJGH4Pcg1WTcdlfFMPXfJqafZVQgmKdhVFS1c2hXGvs4byttpLC9XmI3okV1uMWA==",
       "dev": true
     },
     "svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "storybook": "^7.0.0-beta.8",
     "svelte": "^3.55.1",
     "svelte-check": "^2.9.2",
-    "svelte-icons-pack": "^2.0.0",
+    "svelte-icons-pack": "^2.1.0",
     "svelte-preprocess": "^5.0.0",
     "tailwindcss": "^3.2.4",
     "tslib": "^2.4.1",


### PR DESCRIPTION
Fixes the error shown when importing icons from svelte-icons-pack. We simply needed to upgrade the version since they added type definitions in the last release

# Screenshots

# Review checklist

- [ ] Contains enough appropriate tests
- [ ] Behavior is as expected
- [ ] Clean, well-structured code
