### PR TITLE
Fix/background hexagon

### DIFF
--- a/src/lib/layout/BackgroundHexagon.svelte
+++ b/src/lib/layout/BackgroundHexagon.svelte
@@ -5,13 +5,13 @@
 {#if position === 'right'}
   <img
     alt="NIAEFEUP hexagon logo"
-    class="fixed -right-24 h-full overflow-hidden pt-20 pb-40 sm:right-0 sm:pb-32"
+    class="fixed -right-24 -z-10 h-full overflow-hidden pt-20 pb-40 sm:right-0 sm:pb-32"
     src="/images/outline_white.png"
   />
 {:else}
   <img
     alt="NIAEFEUP hexagon logo"
-    class="pointer-events-none fixed -left-24 h-full overflow-hidden pt-20 pb-40"
+    class="pointer-events-none fixed -left-24 -z-10 h-full overflow-hidden pt-20 pb-40"
     src="/images/outline_white_180.png"
   />
 {/if}


### PR DESCRIPTION
Closes #146 

Adds a negative z-index to the `BackgroundHexagon` component, as to fix it overlapping other components and interfering with functioning of buttons and touch events.