### PR TITLE
Fix/bg color login form

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -33,9 +33,14 @@
     overflow: auto;
   }
 
-  :global(input:-webkit-autofill,input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:focus, input:-webkit-autofill:active) {
-    -webkit-box-shadow: 0 0 0px 1000px rgb(255 233 233 / var(--tw-bg-opacity)) inset;   /*Since we can't alter the browsers background change on autofill fields we add an inner shadow with the desired color*/ 
-    -webkit-text-fill-color: rgb(65 19 21 / .54);
+  :global(
+      input:-webkit-autofill,
+      input:-webkit-autofill,
+      input:-webkit-autofill:hover,
+      input:-webkit-autofill:focus,
+      input:-webkit-autofill:active
+    ) {
+    -webkit-box-shadow: 0 0 0px 1000px rgb(255 233 233 / var(--tw-bg-opacity)) inset; /*Since we can't alter the browsers background change on autofill fields we add an inner shadow with the desired color*/
+    -webkit-text-fill-color: rgb(65 19 21 / 0.54);
   }
-  
 </style>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -33,6 +33,10 @@
     overflow: auto;
   }
 
+  /*
+  A browser autofill option (in loging form for example) may apply a filter to our input fields that clashes with our desired aesthetic,
+  therefore we undo that change and keep the original style
+  */
   :global(
       input:-webkit-autofill,
       input:-webkit-autofill,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -32,4 +32,12 @@
     flex-direction: column;
     overflow: auto;
   }
+
+  :global(input:-webkit-autofill,input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:focus, input:-webkit-autofill:active) {
+    -webkit-box-shadow: 0 0 0px 1000px rgb(255 233 233 / var(--tw-bg-opacity)) inset;   /*Since we can't alter the browsers background change we add an inner shadow with the same defaul color*/ 
+    -webkit-text-fill-color: rgb(65 19 21 / .54);
+    /*.54 should be replaced with var(--tw-bg-opacity) but at least my PC recognized the variable as 1 instead of .54*/
+    /*Possible problem: all input field when autofilled will have this change, even outside of login*/
+  }
+  
 </style>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -34,10 +34,8 @@
   }
 
   :global(input:-webkit-autofill,input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:focus, input:-webkit-autofill:active) {
-    -webkit-box-shadow: 0 0 0px 1000px rgb(255 233 233 / var(--tw-bg-opacity)) inset;   /*Since we can't alter the browsers background change we add an inner shadow with the same defaul color*/ 
+    -webkit-box-shadow: 0 0 0px 1000px rgb(255 233 233 / var(--tw-bg-opacity)) inset;   /*Since we can't alter the browsers background change on autofill fields we add an inner shadow with the desired color*/ 
     -webkit-text-fill-color: rgb(65 19 21 / .54);
-    /*.54 should be replaced with var(--tw-bg-opacity) but at least my PC recognized the variable as 1 instead of .54*/
-    /*Possible problem: all input field when autofilled will have this change, even outside of login*/
   }
   
 </style>


### PR DESCRIPTION
Closes #292 

Altered the login forms to not use the browsers autofill style changes.

## Before
![image](https://github.com/user-attachments/assets/df5c0091-3d72-4aaa-9dc6-b2e272c54526)

## After
![image](https://github.com/user-attachments/assets/ab9b2c27-9344-4fd3-bfd0-c09e089f0cf8)


# Potencial Problems
This will make it so that every input field with autofill will have a pink background and letters, will most likely not become an issue though because few fields with autofill options will have diferent background options. However cresting a custom class for pink autofill inputs could also be done.