### PR TITLE
Fixed navbar

### DIFF
--- a/src/routes/(app)/_components/layout/navbar.svelte
+++ b/src/routes/(app)/_components/layout/navbar.svelte
@@ -42,7 +42,7 @@
   </div>
   <div class="flex items-center justify-end gap-7">
     {#each links as { href, label, pageComp } (label)}
-      {#if currentPage === pageComp}
+      {#if currentPage.startsWith(pageComp)}
         <a {href} class="rounded bg-muted-red-400 p-2" data-testid={label.toLowerCase()}>
           <p class="font-bold">{label}</p>
         </a>


### PR DESCRIPTION
Closes #380
Before, when we changed to a subpage, the subpage topic was highlighted, but when we navigated through the subpages inside the first one, the highlight on the button was missing. 

# Screenshots
<img width="1801" height="958" alt="Captura de ecrã de 2025-12-10 19-14-24" src="https://github.com/user-attachments/assets/eb3034fb-ca5d-420c-903a-bafe3e3375ba" />