### PR TITLE
fix/sideBar_mobile

### DIFF
--- a/src/routes/(app)/_components/layout/sidebar-items.ts
+++ b/src/routes/(app)/_components/layout/sidebar-items.ts
@@ -1,1 +1,7 @@
-export default Object.freeze<string[]>(['Início', 'Eventos', 'Projetos', 'Equipa', 'Contactos']);
+export default Object.freeze([
+  { label: 'Início', href: '/' },
+  { label: 'Eventos', href: '/events' },
+  { label: 'Projetos', href: '/projects' },
+  { label: 'Equipa', href: '/team' },
+  { label: 'Contactos', href: '/contacts' }
+]);

--- a/src/routes/(app)/_components/layout/sidebar.stories.ts
+++ b/src/routes/(app)/_components/layout/sidebar.stories.ts
@@ -22,13 +22,13 @@ export const MobileSidebar = {
 
     await step('Open sidebar', async () => {
       await userEvent.click(await canvas.findByRole('button'));
-      const menuOption = canvas.queryByText(SidebarItems[0]);
+      const menuOption = canvas.queryByText(SidebarItems[0].label);
       await expect(menuOption).toBeTruthy();
     });
 
     await step('Close sidebar', async () => {
       await userEvent.click(await canvas.findByRole('button'));
-      const menuOption = canvas.queryByText(SidebarItems[0]);
+      const menuOption = canvas.queryByText(SidebarItems[0].label);
       await expect(menuOption).toBeNull();
     });
   }

--- a/src/routes/(app)/_components/layout/sidebar.svelte
+++ b/src/routes/(app)/_components/layout/sidebar.svelte
@@ -40,11 +40,11 @@
       {#each SidebarItems as item, i (i)}
         <NavItem selected={selectedIndex === i}>
           <a
-            href="#/"
+            href={item.href}
             onclick={() => {
               selectedIndex = i;
               toggleSidebar();
-            }}>{item}</a
+            }}>{item.label}</a
           >
         </NavItem>
       {/each}

--- a/src/routes/(app)/_components/layout/sidebar.svelte
+++ b/src/routes/(app)/_components/layout/sidebar.svelte
@@ -31,7 +31,11 @@
     class="bg-ni-sidebar absolute z-20 grid h-screen w-screen grid-cols-[1fr_4em] grid-rows-[4em_1fr] justify-items-center overflow-scroll px-2 py-4 sm:invisible"
   >
     <BackgroundHexagon position="left" />
-    <button class="col-start-2 h-fit w-1/2 text-white" onclick={toggleSidebar}>
+    <button
+      class="col-start-2 h-fit w-1/2 text-white"
+      onclick={toggleSidebar}
+      aria-label="Close sidebar"
+    >
       <Icon src={Icons.Close} color="white" size="31px" />
     </button>
     <ul


### PR DESCRIPTION
Closes #[371]

The sidebar already works in mobile mode; you can now select the options correctly and be redirected to the respective page after clicking on the option.

# Screenshots

# Review checklist

- [ ] Contains enough appropriate tests
- [ ] Behavior is as expected
- [ ] Clean, well-structured code
