### PR TITLE
feat(admin): add CSV account creation to admin page

### DIFF
--- a/src/routes/(app)/admin/+page.server.ts
+++ b/src/routes/(app)/admin/+page.server.ts
@@ -6,9 +6,9 @@ import { canEditActivity, canCreateActivity, canDeleteActivity } from '@/lib/api
 import type { BackendError } from '@/types/backend-error';
 
 export const load: PageServerLoad = async ({ fetch }) => {
-  if (!(await canEditActivity(fetch))) {
+  /*if (!(await canEditActivity(fetch))) {
     throw redirect(303, '/');
-  }
+  }*/
 
   let technologies: Technology[] = [];
   let roles: Role[] = [];
@@ -36,9 +36,9 @@ export const load: PageServerLoad = async ({ fetch }) => {
 
 export const actions: Actions = {
   deleteTechnology: async ({ request, fetch }) => {
-    if (!(await canDeleteActivity(fetch))) {
+    /*if (!(await canDeleteActivity(fetch))) {
       throw redirect(303, '/');
-    }
+    }*/
 
     const formData = await request.formData();
     const id = formData.get('id');
@@ -55,9 +55,9 @@ export const actions: Actions = {
   },
 
   addTechnology: async ({ request, fetch }) => {
-    if (!(await canCreateActivity(fetch))) {
+    /*if (!(await canCreateActivity(fetch))) {
       throw redirect(303, '/');
-    }
+    }*/
 
     const requestData = await request.formData();
 
@@ -93,9 +93,9 @@ export const actions: Actions = {
   },
 
   addRole: async ({ request, fetch }) => {
-    if (!(await canCreateActivity(fetch))) {
+    /*if (!(await canCreateActivity(fetch))) {
       throw redirect(303, '/');
-    }
+    }*/
 
     const formData = await request.formData();
     const name = formData.get('name');
@@ -125,5 +125,69 @@ export const actions: Actions = {
 
     const newRole: Role = await res.json();
     return { success: true, data: newRole };
+  },
+
+  createAccounts:async ({ request, fetch }) => {
+    const data = await request.formData();
+    const csv = data.get('csv') as string;
+
+    if (!csv || csv.trim() === '') {
+      error(400, 'CSV is required');
+    }
+    const lines = csv.trim().split('\n');
+    const [_header, ...rows] = lines;
+    
+    if (!_header.toLowerCase().includes('nome') || !_header.toLowerCase().includes('email')) {
+      return { success: false, parseErrors: ['CSV deve ter cabeçalho: Nome,Email'], results: [], failed: [] };
+    }
+    const accounts = [];
+    const parseErrors: string[] = [];
+    for (const row of rows) {
+      if (row.trim() === '') continue;
+      const parts = row.split(',');
+      if (parts.length < 2) {
+        parseErrors.push(`Linha mal formatada (falta vírgula): "${row.trim()}"`);
+        continue;
+      }
+      if (parts.length > 2) {
+        parseErrors.push(`Linha mal formatada (vírgulas a mais): "${row.trim()}"`);
+        continue;
+      }
+      const [nome, email] = parts;
+      accounts.push({ nome: nome.trim(), email: email.trim() });
+    }
+    if (parseErrors.length > 0) {
+      return { success: false, parseErrors, results: [], failed: [] };
+    }
+
+    if (accounts.length === 0) {
+      return { success: false, parseErrors: ['Nenhuma conta encontrada no CSV'], results: [], failed: [] };
+    }
+
+    const results = await Promise.all(
+      accounts.map(async ({ nome, email }) => {
+        const formData = new FormData();
+        formData.append(
+          'account', 
+          new Blob([JSON.stringify({name: nome, email: email, isActive: true})], { 
+            type: 'application/json' 
+          })
+        );
+
+        const res = await fetch('/api/accounts', { method: 'POST', body: formData});
+        const json = await res.json().catch(() => ({}));
+        let errorMsg = null;
+        if (!res.ok) {
+          errorMsg = json?.errors?.[0]?.message ?? 'Erro desconhecido';
+        }
+        return { nome, email, success: res.ok, errorMsg };
+
+      })
+    );
+
+    const failed = results.filter(r => !r.success);
+
+    return {success: failed.length === 0, parseErrors: [], results, failed}; 
   }
+
 };

--- a/src/routes/(app)/admin/+page.server.ts
+++ b/src/routes/(app)/admin/+page.server.ts
@@ -6,9 +6,9 @@ import { canEditActivity, canCreateActivity, canDeleteActivity } from '@/lib/api
 import type { BackendError } from '@/types/backend-error';
 
 export const load: PageServerLoad = async ({ fetch }) => {
-  /*if (!(await canEditActivity(fetch))) {
+  if (!(await canEditActivity(fetch))) {
     throw redirect(303, '/');
-  }*/
+  }
 
   let technologies: Technology[] = [];
   let roles: Role[] = [];
@@ -36,9 +36,9 @@ export const load: PageServerLoad = async ({ fetch }) => {
 
 export const actions: Actions = {
   deleteTechnology: async ({ request, fetch }) => {
-    /*if (!(await canDeleteActivity(fetch))) {
+    if (!(await canDeleteActivity(fetch))) {
       throw redirect(303, '/');
-    }*/
+    }
 
     const formData = await request.formData();
     const id = formData.get('id');
@@ -55,9 +55,9 @@ export const actions: Actions = {
   },
 
   addTechnology: async ({ request, fetch }) => {
-    /*if (!(await canCreateActivity(fetch))) {
+    if (!(await canCreateActivity(fetch))) {
       throw redirect(303, '/');
-    }*/
+    }
 
     const requestData = await request.formData();
 
@@ -93,9 +93,9 @@ export const actions: Actions = {
   },
 
   addRole: async ({ request, fetch }) => {
-    /*if (!(await canCreateActivity(fetch))) {
+    if (!(await canCreateActivity(fetch))) {
       throw redirect(303, '/');
-    }*/
+    }
 
     const formData = await request.formData();
     const name = formData.get('name');

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -2,6 +2,7 @@
   import type { PageData } from './$types';
   import Technologies from './_components/technologies.svelte';
   import Roles from './_components/roles.svelte';
+  import CreateAccounts from './_components/create-accounts.svelte';
   import * as Tabs from '$lib/components/ui/tabs/index.js';
 
   let { data }: { data: PageData } = $props();
@@ -22,12 +23,21 @@
       >
         Tecnologias
       </Tabs.Trigger>
+      <Tabs.Trigger
+        class="relative bg-transparent p-0 text-2xl font-bold transition-all duration-300 after:absolute after:bottom-[-5px] after:left-0 after:h-[0.2em] after:bg-red-500 after:content-[''] data-[state=active]:after:w-full"
+        value="createAccounts"
+      >
+        Criar Contas
+      </Tabs.Trigger>
     </Tabs.List>
     <Tabs.Content value="technologies">
       <Technologies technologies={data.technologies} />
     </Tabs.Content>
     <Tabs.Content value="roles">
       <Roles roles={data.roles} />
+    </Tabs.Content>
+    <Tabs.Content value="createAccounts">
+      <CreateAccounts/>
     </Tabs.Content>
   </Tabs.Root>
 </section>

--- a/src/routes/(app)/admin/_components/create-accounts.svelte
+++ b/src/routes/(app)/admin/_components/create-accounts.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+    import LabelInput from '$lib/components/forms/label-input.svelte';
+    import { enhance } from '$app/forms';
+     interface FailedAccount {
+        nome: string;
+        email: string;
+        errorMsg: string;
+    }
+
+    interface CreateAccountsResult {
+        success: boolean;
+        parseErrors: string[];
+        results: { nome: string; email: string; success: boolean }[];
+        failed: FailedAccount[];
+    }
+
+
+    let parseErrors = $state<string[]>([]);
+    let failedAccounts = $state<FailedAccount[]>([]);
+    let successCount = $state(0);
+
+</script>
+
+<section class="flex w-full flex-col gap-4">
+    <form class="flex flex-col w-full" 
+        method="POST"
+        action="?/createAccounts"
+        use:enhance={() => {
+            parseErrors = [];
+            failedAccounts = [];
+            successCount = 0;
+
+            return async ({ result, update }) => {
+            await update();
+
+                if (result.type === 'success' && result.data) {
+                    const data = result.data as unknown as CreateAccountsResult;
+                    parseErrors = data.parseErrors ?? [];
+                    failedAccounts = data.failed ?? [];
+                    successCount = (data.results ?? []).filter(r => r.success).length;
+                } else {
+                    parseErrors = ['Erro inesperado ao processar o CSV.'];
+                }
+            };
+        }}>
+        <LabelInput
+            label="CSV text"
+            id="csv"
+            name="csv"
+            isTextArea={true}
+            placeholder="Copia aqui o CSV..."
+            required={true}
+            minlength={10}
+            class="rounded-lg bg-white px-4 py-3 text-black"
+        />
+        <button
+            type="submit"
+            class="rounded-xl bg-muted-red-700 p-4 text-lg text-white shadow-xl"
+        >
+            Criar Contas
+        </button>
+    </form>
+    {#if successCount > 0}
+        <p class="text-green-500"> {successCount} conta(s) criada(s) com sucesso!</p>
+    {/if}
+
+    {#if parseErrors.length > 0}
+        <div class="w-full rounded-xl bg-red-900/40 p-4">
+            <p class="font-bold text-red-400"> Erros no CSV:</p>
+            <ul class="mt-2 list-disc pl-4 text-red-400">
+                {#each parseErrors as err}
+                    <li>{err}</li>
+                {/each}
+            </ul>
+        </div>
+    {/if}
+    {#if failedAccounts.length > 0}
+        <div class="w-full rounded-xl bg-red-900/40 p-4">
+            <p class="font-bold text-red-400"> Contas que falharam:</p>
+            <ul class="mt-2 list-disc pl-4 text-red-400">
+                {#each failedAccounts as account}
+                    <li>{account.nome} ({account.email}) — {account.errorMsg}</li>
+                {/each}
+            </ul>
+        </div>
+    {/if}
+  
+    
+</section> 
+


### PR DESCRIPTION
Adds a new section to the admin page that allows admins to create multiple accounts at once by pasting a CSV, solving the process of creating accounts one by one during recruitment season.

Closes #411 

## Changes
- Added `create-accounts.svelte` component with a CSV text input and feedback on success/errors
- Added `createAccounts` server action to `page.server.ts` that parses the CSV and creates accounts via the API
- Added a new "Criar Contas" tab to the admin page

## Screenshots
<img width="1906" height="1000" alt="image" src="https://github.com/user-attachments/assets/fe6d7bb7-d99c-4dda-a0ca-f9be03cce273" />

## Notes
- Account creation only requires name and email — the user will receive an email to set their password. To test this locally, an email service must be configured in the backend (e.g. Mailtrap). Without it, account creation requests will fail.